### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/backend/flickr_scraper.py
+++ b/backend/flickr_scraper.py
@@ -42,7 +42,8 @@ def get_urls(search="honeybees on flowers", n=10, download=False):
                     download_uri(url, dir_path)
 
                 urls.append(url)
-                print(f"{i}/{n} {url}")
+                # Avoid logging the full URL as it may contain the photo 'secret'.
+                print(f"{i}/{n} photo_id={photo.get('id')}")
             except Exception:
                 print(f"{i}/{n} error...")
 


### PR DESCRIPTION
Potential fix for [https://github.com/TheMattBin/Image-Search/security/code-scanning/2](https://github.com/TheMattBin/Image-Search/security/code-scanning/2)

To fix this issue, you should avoid logging URLs that may contain sensitive tokens, specifically those constructed using `photo.get('secret')`. In this case, update the log statement to avoid printing the full URL if it contains the photo's 'secret' field.

The best way is to:
- Redact or completely remove the 'secret' value from the logged URL.
- Alternatively, only log metadata (such as index, ID, or part of the URL that does not include 'secret').
- This only requires changes on line 45 (and optionally, elsewhere you print URLs that may include the secret).
- If you wish to log something for progress feedback, you can print the photo index and ID, or a redacted URL.

No new imports are required. All changes are within the `get_urls` function in backend/flickr_scraper.py.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
