### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text storage of sensitive information

### DIFF
--- a/backend/utils/general.py
+++ b/backend/utils/general.py
@@ -2,13 +2,20 @@ from pathlib import Path
 
 import requests
 from PIL import Image
-
+import re
 
 def download_uri(uri, dir="./"):
     """Downloads file from URI, performing checks and renaming; supports timeout and image format suffix addition."""
     # Download
     dir = Path(dir)
-    f = dir / Path(uri).name  # filename
+    # Strip Flickr 'secret' from filename if present (_[secret]_b.jpg)
+    fname = Path(uri).name
+    # Remove Flickr secret from filename pattern: {id}_{secret}_b.jpg -> {id}_b.jpg
+    import re
+    match = re.match(r"(?P<id>\d+)_(?P<secret>\w+)_b\.jpg", fname)
+    if match:
+        fname = f"{match.group('id')}_b.jpg"
+    f = dir / fname  # sanitized filename
     with open(f, "wb") as file:
         file.write(requests.get(uri, timeout=10).content)
 


### PR DESCRIPTION
Potential fix for [https://github.com/TheMattBin/Image-Search/security/code-scanning/1](https://github.com/TheMattBin/Image-Search/security/code-scanning/1)

To fix the vulnerability, we should remove or obfuscate any sensitive tokens (such as the Flickr photo secret) from the filenames of downloaded files, and optionally consider encrypting the downloaded content if it must remain confidential. The main concern, as flagged by CodeQL, is storing a file that is retrievable only via a secret token, and potentially exposing that token in filenames or unprotected directories.

The lowest-impact fix is to ensure that the downloaded file is named using only non-sensitive photo identifiers (e.g., photo id, server, farm), and to strip out any use of the photo's secret in the saved filename (even if it's present in the URL). The actual image content does not need to be encrypted unless further protection is required, but no part of the filename or directory structure should contain the secret.

In practice:
- In backend/utils/general.py, change `f = dir / Path(uri).name` so that the filename is generated without any sensitive values (such as the secret).
- Strip the secret from the filename if present, possibly by regular expression or by parsing the filename and removing the portion containing the secret.
- Optionally, guard the directory where files are stored with appropriate permissions.
- No need to encrypt image files unless you have private datasets, but if future requirements demand it, an optional encryption can be added.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
